### PR TITLE
Adding basePath to python plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ CMakeLists.txt.user
 edit
 build
 std*.log
+*.bak

--- a/src/runner/uibasewrappers.h
+++ b/src/runner/uibasewrappers.h
@@ -218,6 +218,10 @@ struct IOrganizerWrapper : MOBase::IOrganizer,
   {
     return this->get_override("overwritePath")();
   }
+  virtual QString basePath() const override
+  {
+	return this->get_override("basePath")();
+  }
   virtual MOBase::VersionInfo appVersion() const override
   {
     return this->get_override("appVersion")();


### PR DESCRIPTION
Adds the virtual function override to the boost python wrapper.